### PR TITLE
#22 Enable CDS and virtual threads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM --platform=$BUILDPLATFORM bellsoft/liberica-openjre-alpine:25-cds AS builder
-WORKDIR /application
+WORKDIR /builder
 ARG JAR_FILE=target/openwms-configuration-exec.jar
 COPY ${JAR_FILE} application.jar
-RUN java -Djarmode=tools -jar application.jar extract --layers --launcher --destination extracted
+RUN java -Djarmode=tools -jar application.jar extract --layers --destination extracted
 
 FROM bellsoft/liberica-openjre-alpine:25-cds
 WORKDIR /application
-COPY --from=builder /application/extracted/dependencies/ ./
-COPY --from=builder /application/extracted/spring-boot-loader/ ./
-COPY --from=builder /application/extracted/snapshot-dependencies/ ./
-COPY --from=builder /application/extracted/application/ ./
-ENTRYPOINT ["java", "--enable-native-access=ALL-UNNAMED", "org.springframework.boot.loader.launch.JarLauncher"]
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/application/ ./
+# CDS training run: exits on context refresh and writes the archive used at runtime
+RUN java -XX:ArchiveClassesAtExit=application.jsa -Dspring.context.exit=onRefresh \
+    -Dspring.profiles.active=native -Deureka.client.enabled=false -jar application.jar
+ENTRYPOINT ["java", "-XX:SharedArchiveFile=application.jsa", "--enable-native-access=ALL-UNNAMED", "-jar", "application.jar"]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,9 @@ spring:
     user:
       name: user
       password: sa
+  threads:
+    virtual:
+      enabled: true
 
 owms:
   eureka:


### PR DESCRIPTION
Closes #22.

## Changes
- Dockerfile: extract the jar in the CDS-friendly layout (no launcher, app runs via `java -jar`), add a CDS training run during image build (`-XX:ArchiveClassesAtExit` + `-Dspring.context.exit=onRefresh`, trained offline with the `native` profile and Eureka disabled), start the JVM with `-XX:SharedArchiveFile`.
- `application.yml`: enable `spring.threads.virtual.enabled` - the config server workload (git, file serving, HTTP) is blocking I/O.

## Verification
- Container startup measured from logs: **~4.5s → 1.26s**.
- Image built and run locally (arm64), health and config-serving endpoints verified; branch CI validates the amd64 build including the training run.

Note: the training run executes on the target platform, so the arm64 leg of the multi-arch master build runs under QEMU and adds a few minutes of build time.